### PR TITLE
Add deoplete completion source name to the documentation

### DIFF
--- a/doc/UltiSnips.txt
+++ b/doc/UltiSnips.txt
@@ -1778,7 +1778,8 @@ offers a really nice completion dialogue for snippets.
 neocomplete - UltiSnips ships with a source for neocomplete and therefore
 offers out of the box completion dialogue support for it too.
 
-deoplete - The successor of neocomplete is also supported.
+deoplete - The successor of neocomplete is also supported. The completion 
+source is called 'ultisnips'.
 
 unite - UltiSnips has a source for unite. As an example of how you can use
 it add the following function and mappings to your vimrc: >


### PR DESCRIPTION
When using a custom set of deoplete sources (as opposed to using everything) it can sometimes be hard to figure out *which* source you need to enable. Is it "us," "UltiSnips," "ultisnips," or something else entirely? 

This PR adds the completion source name to the documentation so that people don't have to dig through the code.